### PR TITLE
Fix month-cell column direction

### DIFF
--- a/by_year/styles.css
+++ b/by_year/styles.css
@@ -71,13 +71,13 @@
 
   .year-cell {
     display: grid;
-    grid-template-columns: 1fr 1fr 1fr 1fr;
     gap: var(--week-gap);
   }
 
   .month-cell {
     display: grid;
     grid-row-gap: var(--week-gap);
+    grid-template-columns: 1fr 1fr 1fr 1fr;
   }
 
   .year-label {


### PR DESCRIPTION
This fixes the column direction. Grid-template-columns were accidentally set to years intead of months. Related issue: #4 